### PR TITLE
[BAC-4257] Modifying the simple papertrail logger format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,8 @@ export class SimplePapertrailLogger {
         if (!message.trim()) {
             return;
         }
-        let newMessage = `${this.uniqueId}`;
-        if (this.opts.logIdentifier) {
-            newMessage += ` ${this.opts.logIdentifier}`;
-        }
-        newMessage += ` | ${message}${EOL}`
+
+        let newMessage = `<14>1 - ${this.opts.logIdentifier} ${this.uniqueId} - - - ${message}${EOL}`;
         this.messageBuffer += newMessage;
     }
 


### PR DESCRIPTION
Making the logger format look more like syslog, which has specific fields and tokens and one of them represents the hostname. Setting hostname to the logIdentifier should do the trick and get it registered up in papertrail!